### PR TITLE
Fixed issue: if last row didn't include newline at the end it wouldn't be sent to the delegate

### DIFF
--- a/fgCSVReader.cs
+++ b/fgCSVReader.cs
@@ -87,6 +87,8 @@ public class fgCSVReader
             default:
                 // other cases, add char
                 cur_item.Append(c);
+                if(cur_file_index == (file_length))
+                    goto case '\n';
                 break;
             }
         }


### PR DESCRIPTION

Second attempt at fixing this. This time it works, tested on my own data.